### PR TITLE
Use a card based prediction entry design for users.

### DIFF
--- a/STRUDEL/package-lock.json
+++ b/STRUDEL/package-lock.json
@@ -1359,6 +1359,12 @@
         "@types/node": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.161",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -5081,9 +5087,14 @@
       "version": "file:../ENKEL",
       "requires": {
         "bcrypt": "^5.0.0",
+        "compression": "^1.7.4",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
+        "helmet": "^4.1.1",
         "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.20",
+        "moment": "^2.29.0",
+        "node-fetch": "^2.6.1",
         "pg": "^8.3.3",
         "reflect-metadata": "^0.1.13",
         "typeorm": "^0.2.26",
@@ -5896,6 +5907,35 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
+        "compressible": {
+          "version": "2.0.18",
+          "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+          "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+          "requires": {
+            "mime-db": ">= 1.43.0 < 2"
+          }
+        },
+        "compression": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+          "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+          "requires": {
+            "accepts": "~1.3.5",
+            "bytes": "3.0.0",
+            "compressible": "~2.0.16",
+            "debug": "2.6.9",
+            "on-headers": "~1.0.2",
+            "safe-buffer": "5.1.2",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+              "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+            }
+          }
+        },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6684,6 +6724,11 @@
           "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
           "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
         },
+        "helmet": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.1.1.tgz",
+          "integrity": "sha512-Avg4XxSBrehD94mkRwEljnO+6RZx7AGfk8Wa6K1nxaU+hbXlFOhlOIMgPfFqOYQB/dBCsTpootTGuiOG+CHiQA=="
+        },
         "highlight.js": {
           "version": "9.18.3",
           "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
@@ -7120,6 +7165,11 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
+        "moment": {
+          "version": "2.29.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
+          "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -7174,6 +7224,11 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
           "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "node-pre-gyp": {
           "version": "0.15.0",
@@ -7322,6 +7377,11 @@
           "requires": {
             "ee-first": "1.1.1"
           }
+        },
+        "on-headers": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+          "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
         },
         "once": {
           "version": "1.4.0",
@@ -11299,8 +11359,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",

--- a/STRUDEL/package.json
+++ b/STRUDEL/package.json
@@ -13,6 +13,7 @@
     "enkel": "file:../ENKEL",
     "jquery": "^3.5.1",
     "jsonwebtoken": "^8.5.1",
+    "lodash": "^4.17.20",
     "moment": "^2.29.0",
     "reflect-metadata": "^0.1.13",
     "vue": "^2.6.11",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.0",
+    "@types/lodash": "^4.14.161",
     "@types/node": "^14.6.4",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",

--- a/STRUDEL/src/App.vue
+++ b/STRUDEL/src/App.vue
@@ -24,7 +24,6 @@ export default class App extends Vue {}
 </script>
 
 <style lang="scss">
-@use "sass:map";
 $enable-shadows: true;
 $enable-gradients: true;
 $theme-colors: (

--- a/STRUDEL/src/components/EntityManagement.vue
+++ b/STRUDEL/src/components/EntityManagement.vue
@@ -70,6 +70,8 @@ export default class EntityManagement extends BaseComponent {
   @Prop()
   apiEndpoint: string | undefined;
   @Prop()
+  GETextension: string | undefined;
+  @Prop()
   entityFormComponent: Vue | undefined;
   @Prop()
   fields: Record<string, unknown> | undefined;
@@ -77,7 +79,12 @@ export default class EntityManagement extends BaseComponent {
   populateNewEntity: Function | undefined;
 
   async getAllEntities(apiEndpoint: string) {
-    return await this.callENKEL(apiEndpoint)
+    let endpoint = apiEndpoint;
+    if (this.GETextension) {
+      endpoint += this.GETextension;
+    }
+
+    return await this.callENKEL(endpoint)
       .then(res => res.json())
       .then(json => {
         this.entityList = json;
@@ -90,7 +97,7 @@ export default class EntityManagement extends BaseComponent {
     }
   }
 
-  @Watch("apiEndpoint")
+  @Watch("GETextension")
   endpointUpdated(apiEndpoint: string) {
     if (apiEndpoint) {
       this.getAllEntities(apiEndpoint);

--- a/STRUDEL/src/components/PredictionEntry.vue
+++ b/STRUDEL/src/components/PredictionEntry.vue
@@ -32,7 +32,19 @@
             :deck="entityList[date].length < 5"
             v-if="weekSelection === -1 || (entityList[date] && entityList[date].length > 0)"
           >
-            <b-card v-for="entity in entityList[date]" :key="entity.id" no-body class="shadow">
+            <b-card
+              v-for="entity in entityList[date]"
+              :key="entity.id"
+              no-body
+              class="shadow"
+              :border-variant="
+                entity.fixture.fixtureResult
+                  ? entity.fixture.fixtureResult === entity.prediction
+                    ? 'success'
+                    : 'danger'
+                  : null
+              "
+            >
               <b-card-body class="px-3 pt-3 pb-2">
                 <b-form-radio-group
                   buttons
@@ -63,6 +75,11 @@
                   </b-form-radio>
                 </b-form-radio-group>
               </b-card-body>
+
+              <b-card-body v-if="entity.fixture.fixtureResult !== null">
+                <span>Actual Result: {{ formatFixtureResult(entity.fixture.fixtureResult) }}</span>
+              </b-card-body>
+
               <b-button
                 class="w-100 p-1"
                 variant="outline-success"
@@ -219,6 +236,17 @@ export default class PredictionEntry extends BaseComponent {
 
   formatDate(date: string | Date): string {
     return moment(date).format("ddd, Do MMM");
+  }
+
+  formatFixtureResult(result: string) {
+    switch (result) {
+      case "H":
+        return "Home Win";
+      case "A":
+        return "Away Win";
+      case "D":
+        return "Draw";
+    }
   }
 }
 </script>

--- a/STRUDEL/src/components/entity-forms/PredictionForm.vue
+++ b/STRUDEL/src/components/entity-forms/PredictionForm.vue
@@ -2,24 +2,28 @@
   <div id="user-form">
     <b-row align-h="center">
       <b-form v-if="entityModel != null && showForm" @submit.prevent="emitSubmitEvent">
-        <label class="sr-only" id="input-label-team-id" for="input-team-id">Prediction ID</label>
+        <label class="sr-only" id="input-label-prediction-id" for="input-prediction-id">Prediction ID</label>
         <b-input-group class="mr-2 my-3" prepend="Prediction ID">
-          <b-form-input id="input-team-id" v-model="entityModel.id" disabled></b-form-input>
+          <b-form-input id="input-prediction-id" v-model="entityModel.id" disabled></b-form-input>
         </b-input-group>
 
-        <label class="sr-only" id="input-label-team-name" for="input-team-name">Fixture</label>
+        <label class="sr-only" id="input-label-fixture" for="input-fixture">Fixture</label>
         <b-input-group class="my-3" prepend="Fixture">
-          <b-form-input id="input-team-name" v-model.number="entityModel.fixture.id" required></b-form-input>
+          <b-form-input id="input-fixture" v-model.number="entityModel.fixture.id" required></b-form-input>
         </b-input-group>
 
-        <label class="sr-only" id="input-label-team-name" for="input-team-name">User</label>
+        <label class="sr-only" id="input-label-user" for="input-user">User</label>
         <b-input-group class="my-3" prepend="User">
-          <b-form-input id="input-team-name" v-model.number="entityModel.user.id" required></b-form-input>
+          <b-form-input id="input-user" v-model.number="entityModel.user.id" required></b-form-input>
         </b-input-group>
 
-        <label class="sr-only" id="input-label-team-name" for="input-team-name">Prediction</label>
+        <label class="sr-only" id="input-label-prediction" for="input-prediction">Prediction</label>
         <b-input-group class="my-3" prepend="Prediction">
-          <b-form-input id="input-team-name" v-model="entityModel.prediction"></b-form-input>
+          <b-form-select
+            id="input-prediction"
+            :options="predictionOptions"
+            v-model="entityModel.prediction"
+          ></b-form-select>
         </b-input-group>
 
         <b-button class="ml-2 my-2" variant="success" type="submit">Save Entity</b-button>
@@ -37,6 +41,13 @@ import { EntityForm } from "@/components/entity-forms/EntityForm.ts";
   components: {}
 })
 export default class PredictionForm extends EntityForm {
+  predictionOptions = [
+    { value: null, text: "Prediction", disabled: true },
+    { value: "H", text: "Home Win" },
+    { value: "D", text: "Draw" },
+    { value: "A", text: "Away Win" }
+  ];
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createNewEntityModel(value: any) {
     value.new = null;

--- a/STRUDEL/src/pages/Fixtures.vue
+++ b/STRUDEL/src/pages/Fixtures.vue
@@ -4,7 +4,7 @@
       <h3 class="my-5 mx-3">{{ isAdmin() ? "Maintain" : "View" }} Fixtures</h3>
     </b-row>
     <EntityManagement
-      v-bind:apiEndpoint="'/iapi/fixtures'"
+      :apiEndpoint="'/iapi/fixtures'"
       :entityFormComponent="FixtureForm"
       :fields="fields"
       :populateNewEntity="populateNewEntity"

--- a/STRUDEL/src/pages/Predictions.vue
+++ b/STRUDEL/src/pages/Predictions.vue
@@ -24,6 +24,7 @@
     </b-row>
     <EntityManagement
       :apiEndpoint="apiEndpoint"
+      :GETextension="GETextension"
       :entityFormComponent="PredictionForm"
       :fields="fields"
     ></EntityManagement>
@@ -51,9 +52,11 @@ export default class Predictions extends BaseComponent {
     .add(1, "week")
     .format("YYYY-MM-DD");
 
-  get apiEndpoint() {
-    return `/iapi/predictions/bydate?startDate=${this.startDate}&endDate=${this.endDate}`;
+  get GETextension() {
+    return `/bydate?startDate=${this.startDate}&endDate=${this.endDate}`;
   }
+
+  apiEndpoint = "/iapi/predictions";
 
   fields = [
     { key: "id", sortable: true, label: "id" },

--- a/STRUDEL/src/pages/Teams.vue
+++ b/STRUDEL/src/pages/Teams.vue
@@ -3,11 +3,7 @@
     <b-row>
       <h3 class="my-5 mx-3">Maintain Teams</h3>
     </b-row>
-    <EntityManagement
-      v-bind:apiEndpoint="'/iapi/teams'"
-      :entityFormComponent="TeamForm"
-      :fields="fields"
-    ></EntityManagement>
+    <EntityManagement :apiEndpoint="'/iapi/teams'" :entityFormComponent="TeamForm" :fields="fields"></EntityManagement>
   </div>
 </template>
 

--- a/STRUDEL/src/pages/Users.vue
+++ b/STRUDEL/src/pages/Users.vue
@@ -3,11 +3,7 @@
     <b-row>
       <h3 class="my-5 mx-3">Maintain Users</h3>
     </b-row>
-    <EntityManagement
-      v-bind:apiEndpoint="'/iapi/users'"
-      :entityFormComponent="UserForm"
-      :fields="fields"
-    ></EntityManagement>
+    <EntityManagement :apiEndpoint="'/iapi/users'" :entityFormComponent="UserForm" :fields="fields"></EntityManagement>
   </div>
 </template>
 


### PR DESCRIPTION
Mainly fixes issue #22. Also fix issues relating to inability to save certain entities due to previous changes in apiEndpoints.

Prediction entry screen for previous week now shows the actual result for that fixture, and highlights in green/red if the prediction was correct/incorrect.