### PR TITLE
Add prediction probability to Prediction entity

### DIFF
--- a/ENKEL/STRUDAL/DAO/FixtureDAO.ts
+++ b/ENKEL/STRUDAL/DAO/FixtureDAO.ts
@@ -17,8 +17,8 @@ export class FixtureDAO extends BaseDAO<Fixture> {
       .leftJoinAndSelect("fixture.predictions", "predictions")
       .leftJoinAndSelect("predictions.user", "user")
       .select(["fixture", "homeTeam", "awayTeam", "predictions.prediction", "user.fullName"])
-      .orderBy("fixture.date", "DESC")
-      .addOrderBy("fixture.time", "DESC")
+      .orderBy("fixture.date", "ASC")
+      .addOrderBy("fixture.time", "ASC")
       .addOrderBy("user.fullName", "ASC")
       .getMany();
   }
@@ -34,8 +34,8 @@ export class FixtureDAO extends BaseDAO<Fixture> {
       .where({
         date: pkg.Between(startDate.format("YYYY-MM-DD"), endDate.format("YYYY-MM-DD")),
       })
-      .orderBy("fixture.date", "DESC")
-      .addOrderBy("fixture.time", "DESC")
+      .orderBy("fixture.date", "ASC")
+      .addOrderBy("fixture.time", "ASC")
       .addOrderBy("user.fullName", "ASC")
       .getMany();
   }

--- a/ENKEL/STRUDAL/entity/Prediction.ts
+++ b/ENKEL/STRUDAL/entity/Prediction.ts
@@ -14,6 +14,15 @@ export class Prediction extends BaseEntity {
   @Column({ type: "enum", enum: FixtureResult, nullable: true })
   prediction!: FixtureResult;
 
+  @Column({ type: "float", nullable: true })
+  homeWinProbability?: number;
+
+  @Column({ type: "float", nullable: true })
+  drawProbability?: number;
+
+  @Column({ type: "float", nullable: true })
+  awayWinProbability?: number;
+
   @ManyToOne(() => UserLogin)
   user!: Partial<UserLogin>;
 }

--- a/ENKEL/STRUDAL/entity/entites.swagger.ts
+++ b/ENKEL/STRUDAL/entity/entites.swagger.ts
@@ -59,14 +59,23 @@ export const entitySchemas = {
       id: {
         type: "integer",
       },
+      prediction: {
+        type: "string",
+      },
+      homeWinProbability: {
+        type: "number",
+      },
+      drawProbability: {
+        type: "number",
+      },
+      awayWinProbability: {
+        type: "number",
+      },
       fixture: {
         $ref: "#/components/schemas/Fixture",
       },
       user: {
         $ref: "#/components/schemas/User",
-      },
-      prediction: {
-        type: "string",
       },
     },
   },

--- a/ENKEL/server/iapi/apiResponse.ts
+++ b/ENKEL/server/iapi/apiResponse.ts
@@ -34,6 +34,7 @@ export const EntityApiResponseSchema = {
           { $ref: "#/components/schemas/Team" },
           { $ref: "#/components/schemas/UserLogin" },
         ],
+        nullable: true,
       },
     },
   },

--- a/ENKEL/server/iapi/basicEntityOperation.swagger.ts
+++ b/ENKEL/server/iapi/basicEntityOperation.swagger.ts
@@ -1,6 +1,6 @@
 export function generateCRUDOperationDocs(entityName: string, pathName: string | null = null): Record<string, unknown> {
   if (pathName === null) {
-    pathName = entityName + "s";
+    pathName = entityName;
   }
 
   const CRUDOperations: Record<string, unknown> = {};
@@ -31,7 +31,7 @@ export function generateCRUDOperationDocs(entityName: string, pathName: string |
         content: {
           "application/json": {
             schema: {
-              $ref: `#/components/schemas/EntityApiResponse`,
+              $ref: `#/components/schemas/${entityName}`,
             },
           },
         },


### PR DESCRIPTION
Adds a Home, Draw, and Away win probability fields to the Prediction Entity.

Docs update to fix issue with PUT endpoints having the wrong entity schema